### PR TITLE
Use 404 Not Found error codes when  not present

### DIFF
--- a/src/main/resources/swagger/ga4gh-tool-discovery.yaml
+++ b/src/main/resources/swagger/ga4gh-tool-discovery.yaml
@@ -89,7 +89,7 @@ paths:
           description: The tool descriptor.
           schema:
             $ref: '#/definitions/ToolDescriptor'
-        '501':
+        '404':
           description: The tool can not be output in the specified format.
           schema:
             $ref: '#/definitions/Error'
@@ -108,7 +108,7 @@ paths:
           description: The tool payload.
           schema:
             $ref: '#/definitions/ToolDockerfile'
-        '400':
+        '404':
           description: The tool payload is not present in the service.
           schema:
             $ref: '#/definitions/Error'


### PR DESCRIPTION
When a Dockerfile or a CWL definition is not present, API should return a 404 Not Found error, instead of  4xx, 5xx error codes.
Indeed, if a resource is not there, this is not an error, only an unavailable resource.