### PR TITLE
Feature/trsv changes

### DIFF
--- a/src/main/resources/swagger/GA4GH.proto
+++ b/src/main/resources/swagger/GA4GH.proto
@@ -1,0 +1,294 @@
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+
+import "google/api/annotations.proto";
+
+
+message GetToolClassesResponse {
+    repeated ToolClass items = 1;
+}
+
+message GetToolsRequest {
+    // The author of the tool (TODO a thought occurs, are we assuming that the author of the CWL and the image are the same?).
+    string author = 1;
+    // The description of the tool.
+    string description = 2;
+    // A unique identifier of the tool, scoped to this registry, for example `123456`
+    string id = 3;
+    int32 limit = 4;
+    // The name of the image.
+    string name = 5;
+    string offset = 6;
+    // The organization in the registry that published the image.
+    string organization = 7;
+    // The image registry that contains the image.
+    string registry = 8;
+    // The name of the tool.
+    string toolname = 9;
+}
+
+message GetToolsResponse {
+    repeated Tool items = 1;
+}
+
+message GetToolsIdRequest {
+    // A unique identifier of the tool, scoped to this registry, for example `123456`
+    string id = 1;
+}
+
+message GetToolsIdVersionsRequest {
+    // A unique identifier of the tool, scoped to this registry, for example `123456`
+    string id = 1;
+}
+
+message GetToolsIdVersionsResponse {
+    repeated ToolVersion items = 1;
+}
+
+message GetToolsIdVersionsVersion_idRequest {
+    // A unique identifier of the tool, scoped to this registry, for example `123456`
+    string id = 1;
+    // An identifier of the tool version, scoped to this registry, for example `v1`
+    string version_id = 2;
+}
+
+message GetToolsIdVersionsVersion_idDescriptorRequest {
+    // A unique identifier of the tool, scoped to this registry, for example `123456`
+    string id = 1;
+    // The output type of the descriptor. If not specified it is up to the underlying implementation to determine which output type to return. Plain types return the bare descriptor while the "non-plain" types return a descriptor wrapped with metadata
+    enum GetToolsIdVersionsVersion_idDescriptorRequest_Type {
+        CWL = 0;
+        WDL = 1;
+        PLAIN_CWL = 2;
+        PLAIN_WDL = 3;
+    }
+    GetToolsIdVersionsVersion_idDescriptorRequest_Type type = 2;
+    // An identifier of the tool version for this particular tool registry, for example `v1`
+    string version_id = 3;
+}
+
+message GetToolsIdVersionsVersion_idDescriptorRelative_pathRequest {
+    // A unique identifier of the tool, scoped to this registry, for example `123456`
+    string id = 1;
+    // A relative path to the additional file (same directory or subdirectories), for example 'foo.cwl' would return a 'foo.cwl' from the same directory as the main descriptor
+    string relative_path = 2;
+    // The output type of the descriptor. If not specified it is up to the underlying implementation to determine which output type to return.  Plain types return the bare descriptor while the "non-plain" types return a descriptor wrapped with metadata
+    enum GetToolsIdVersionsVersion_idDescriptorRelative_pathRequest_Type {
+        CWL = 0;
+        WDL = 1;
+        PLAIN_CWL = 2;
+        PLAIN_WDL = 3;
+    }
+    GetToolsIdVersionsVersion_idDescriptorRelative_pathRequest_Type type = 3;
+    // An identifier of the tool version for this particular tool registry, for example `v1`
+    string version_id = 4;
+}
+
+message GetToolsIdVersionsVersion_idDockerfileRequest {
+    // A unique identifier of the tool, scoped to this registry, for example `123456`
+    string id = 1;
+    // An identifier of the tool version for this particular tool registry, for example `v1`
+    string version_id = 2;
+}
+
+message GetToolsIdVersionsVersion_idTestsRequest {
+    // A unique identifier of the tool, scoped to this registry, for example `123456`
+    string id = 1;
+    // The output type of the descriptor. If not specified it is up to the underlying implementation to determine which output type to return. Plain types return the bare descriptor while the "non-plain" types return a descriptor wrapped with metadata
+    enum GetToolsIdVersionsVersion_idTestsRequest_Type {
+        CWL = 0;
+        WDL = 1;
+        PLAIN_CWL = 2;
+        PLAIN_WDL = 3;
+    }
+    GetToolsIdVersionsVersion_idTestsRequest_Type type = 2;
+    // An identifier of the tool version for this particular tool registry, for example `v1`
+    string version_id = 3;
+}
+
+message GetToolsIdVersionsVersion_idTestsResponse {
+    repeated ToolTests items = 1;
+}
+
+enum DescriptorType {
+    CWL = 0;
+    WDL = 1;
+}
+
+message Error {
+    int32 code = 1;
+    string message = 2;
+}
+
+message Metadata {
+    // The version of the GA4GH tool-registry API supported by this registry
+    string api_version = 1;
+    // A country code for the registry (ISO 3166-1 alpha-3)
+    string country = 2;
+    // A friendly name that can be used in addition to the hostname to describe a registry
+    string friendly_name = 3;
+    // The version of this registry
+    string version = 4;
+}
+
+message Tool {
+    // Contact information for the author of this tool entry in the registry. (More complex authorship information is handled by the descriptor)
+    string author = 1;
+    // An array of IDs for the applications that are stored inside this tool (for example `https://bio.tools/tool/mytum.de/SNAP2/1`)
+    repeated string contains = 2;
+    // The description of the tool.
+    string description = 3;
+    // A unique identifier of the tool, scoped to this registry, for example `123456` or `123456_v1`
+    string id = 4;
+    // The version of this tool in the registry. Iterates when fields like the description, author, etc. are updated.
+    string meta_version = 5;
+    // The organization that published the image.
+    string organization = 6;
+    // Reports whether this tool has been signed.
+    bool signed = 7;
+    ToolClass toolclass = 8;
+    // The name of the tool.
+    string toolname = 9;
+    // The URL for this tool in this registry, for example `http://agora.broadinstitute.org/tools/123456`
+    string url = 10;
+    // Reports whether this tool has been verified by a specific organization or individual
+    bool verified = 11;
+    // Source of metadata that can support a verified tool, such as an email or URL
+    string verified_source = 12;
+    // A list of versions for this tool
+    repeated ToolVersion versions = 13;
+}
+
+message ToolClass {
+    // A longer explanation of what this class is and what it can accomplish
+    string description = 1;
+    // The unique identifier for the class
+    string id = 2;
+    // A short friendly name for the class
+    string name = 3;
+}
+
+message ToolDescriptor {
+    // The descriptor that represents this version of the tool. (CWL or WDL)
+    string descriptor = 1;
+    DescriptorType type = 2;
+    // Optional url to the tool descriptor used to build this image, should include version information, and can include a git hash (e.g. https://raw.githubusercontent.com/ICGC-TCGA-PanCancer/pcawg_delly_workflow/ea2a5db69bd20a42976838790bc29294df3af02b/delly_docker/Delly.cwl )
+    string url = 3;
+}
+
+message ToolDockerfile {
+    // The dockerfile content for this tool.
+    string dockerfile = 1;
+    // Optional url to the dockerfile used to build this image, should include version information, and can include a git hash  (e.g. https://raw.githubusercontent.com/ICGC-TCGA-PanCancer/pcawg_delly_workflow/c83478829802b4d36374870843821abe1b625a71/delly_docker/Dockerfile )
+    string url = 2;
+}
+
+message ToolTests {
+    // The test JSON content for this tool.
+    string test = 1;
+    // Optional url to the test JSON used to test this tool
+    string url = 2;
+}
+
+message ToolVersion {
+    // The type (or types) of descriptors available.
+    repeated DescriptorType descriptor_type = 1;
+    // Reports if this tool has a dockerfile available.
+    bool dockerfile = 2;
+    // An identifier of the version of this tool for this particular tool registry, for example `v1`
+    string id = 3;
+    // The docker path to the image (and version) for this tool. (e.g. quay.io/seqware/seqware_full/1.1)
+    string image = 4;
+    // The version of this tool version in the registry. Iterates when fields like the description, author, etc. are updated.
+    string meta_version = 5;
+    // The name of the version.
+    string name = 6;
+    // The URL for this tool in this registry, for example `http://agora.broadinstitute.org/tools/123456/1`
+    string url = 7;
+    // Reports whether this tool has been verified by a specific organization or individual
+    bool verified = 8;
+    // Source of metadata that can support a verified tool, such as an email or URL
+    string verified_source = 9;
+}
+
+service TrsService {
+    // Return some metadata that is useful for describing this registry
+    // 
+    // Return some metadata that is useful for describing this registry
+    rpc GetMetadata(google.protobuf.Empty) returns (Metadata) {
+      option (google.api.http) = {
+        get: "/api/ga4gh/v1/metadata"
+      };
+    }
+    // List all tool types
+    // 
+    // This endpoint returns all tool-classes available
+    rpc GetToolClasses(google.protobuf.Empty) returns (GetToolClassesResponse) {
+      option (google.api.http) = {
+        get: "/api/ga4gh/v1/toolClasses"
+      };
+    }
+    // List all tools
+    // 
+    // This endpoint returns all tools available or a filtered subset using metadata query parameters.
+    rpc GetTools(GetToolsRequest) returns (GetToolsResponse) {
+      option (google.api.http) = {
+        get: "/api/ga4gh/v1/tools"
+      };
+    }
+    // List one specific tool, acts as an anchor for self references
+    // 
+    // This endpoint returns one specific tool (which has ToolVersions nested inside it)
+    rpc GetToolsId(GetToolsIdRequest) returns (Tool) {
+      option (google.api.http) = {
+        get: "/api/ga4gh/v1/tools/{id}"
+      };
+    }
+    // List versions of a tool
+    // 
+    // Returns all versions of the specified tool
+    rpc GetToolsIdVersions(GetToolsIdVersionsRequest) returns (GetToolsIdVersionsResponse) {
+      option (google.api.http) = {
+        get: "/api/ga4gh/v1/tools/{id}/versions"
+      };
+    }
+    // List one specific tool version, acts as an anchor for self references
+    // 
+    // This endpoint returns one specific tool version
+    rpc GetToolsIdVersionsVersion_id(GetToolsIdVersionsVersion_idRequest) returns (ToolVersion) {
+      option (google.api.http) = {
+        get: "/api/ga4gh/v1/tools/{id}/versions/{version_id}"
+      };
+    }
+    // Get the tool descriptor (CWL/WDL) for the specified tool.
+    // 
+    // Returns the CWL or WDL descriptor for the specified tool.
+    rpc GetToolsIdVersionsVersion_idDescriptor(GetToolsIdVersionsVersion_idDescriptorRequest) returns (ToolDescriptor) {
+      option (google.api.http) = {
+        get: "/api/ga4gh/v1/tools/{id}/versions/{version_id}/descriptor"
+      };
+    }
+    // Get additional tool descriptor files (CWL/WDL) relative to the main file
+    // 
+    // Returns additional CWL or WDL descriptors for the specified tool in the same or subdirectories
+    rpc GetToolsIdVersionsVersion_idDescriptorRelative_path(GetToolsIdVersionsVersion_idDescriptorRelative_pathRequest) returns (ToolDescriptor) {
+      option (google.api.http) = {
+        get: "/api/ga4gh/v1/tools/{id}/versions/{version_id}/descriptor/{relative_path}"
+      };
+    }
+    // Get the dockerfile for the specified image.
+    // 
+    // Returns the dockerfile for the specified image.
+    rpc GetToolsIdVersionsVersion_idDockerfile(GetToolsIdVersionsVersion_idDockerfileRequest) returns (ToolDockerfile) {
+      option (google.api.http) = {
+        get: "/api/ga4gh/v1/tools/{id}/versions/{version_id}/dockerfile"
+      };
+    }
+    // Get an array of test JSONs suitable for use with this descriptor type.
+    rpc GetToolsIdVersionsVersion_idTests(GetToolsIdVersionsVersion_idTestsRequest) returns (GetToolsIdVersionsVersion_idTestsResponse) {
+      option (google.api.http) = {
+        get: "/api/ga4gh/v1/tools/{id}/versions/{version_id}/tests"
+      };
+    }
+}

--- a/src/main/resources/swagger/README.md
+++ b/src/main/resources/swagger/README.md
@@ -5,7 +5,12 @@ A protobuf file will be automatically generated through Travis using Openapi2pro
 A 2nd swagger yaml will be generated from the newly generated protobuf file using protoc-gen-swagger and will have basic checks to determine that vital information is not lost between these conversions.
 After successful conversion checks, the protobuf file will be uploaded back to this repository and branch using the repository's deploy key.
 
-A few notes:
+### Current protobuf generation status:
+The .travis.yml that automatically generates the protobuf file is currently not present in this pull request because there's currently no deploy key for this repository yet (Travis would definitely fail the build).
+
+See https://github.com/garyluu/validator/blob/master/.travis.yml for an similar travis file that automatically generates and uploads the protobuf file.
+
+### A few notes:
 Some information is lost during the swagger.yaml to protobuf conversion such as optional/required properties, headers, content-type, etc.
 If making these type of changes in the swagger yaml, ensure there's a comment in the swagger yaml indicating it.
 In general, comments are carried over from swagger to protobuf.  In the event of ambiguity or conversion issues, use comments.

--- a/src/main/resources/swagger/README.md
+++ b/src/main/resources/swagger/README.md
@@ -1,0 +1,24 @@
+## Instruction for modifying the TRS
+
+To make changes to the TRS, modify the swagger yaml file.  This swagger yaml file will be used in the validation server.
+A protobuf file will be automatically generated through Travis using Openapi2proto and some post processing.
+A 2nd swagger yaml will be generated from the newly generated protobuf file using protoc-gen-swagger and will have basic checks to determine that vital information is not lost between these conversions.
+After successful conversion checks, the protobuf file will be uploaded back to this repository and branch using the repository's deploy key.
+
+A few notes:
+Some information is lost during the swagger.yaml to protobuf conversion such as optional/required properties, headers, content-type, etc.
+If making these type of changes in the swagger yaml, ensure there's a comment in the swagger yaml indicating it.
+In general, comments are carried over from swagger to protobuf.  In the event of ambiguity or conversion issues, use comments.
+
+https://groups.google.com/a/genomicsandhealth.org/forum/?hl=en-GB#!topic/ga4gh-cloud/ElieFuwHgcM lists a bunch of other issues that will need to be taken into account when editing the swagger yaml.
+
+To preserve as much compatibility with protobuf as possible, here are some things to avoid using in the swagger yaml:
+- Required properties in objects.  Protobuf will consider all of them as optional
+- All header info for example: no-cache, max-age, max-stale, all encoding related headers, authorization, content-type, etc
+- Enum path parameters
+- Custom error response objects
+- More than 1 successful response object
+- Global enums that have the same property names
+- HTTP methods that are HEAD, TRACE, OPTIONS, and CONNECT due to tooling (protobuf could use custom http patterns but too complicated for automated conversion)
+- Nullable properties (even swagger doesn't support it very well)
+- all vendor extensions such as x-example, x-description, x-summary, etc

--- a/src/main/resources/swagger/ga4gh-tool-discovery.yaml
+++ b/src/main/resources/swagger/ga4gh-tool-discovery.yaml
@@ -401,10 +401,7 @@ definitions:
         type: array
         description: The type (or types) of descriptors available.
         items:
-          type: string
-          enum:
-            - CWL
-            - WDL
+          $ref: '#/definitions/DescriptorType'
       dockerfile:
         type: boolean
         description: Reports if this tool has a dockerfile available.
@@ -417,6 +414,11 @@ definitions:
       verified_source:
         type: string
         description: Source of metadata that can support a verified tool, such as an email or URL
+  DescriptorType:
+    type: string
+    enum:
+      - CWL
+      - WDL
   ToolDescriptor:
     type: object
     description: A tool descriptor is a metadata document that describes one or more tools.
@@ -425,10 +427,7 @@ definitions:
       - descriptor
     properties:
       type:
-        type: string
-        enum:
-          - CWL
-          - WDL
+        $ref: '#/definitions/DescriptorType'
       descriptor:
         type: string
         description: The descriptor that represents this version of the tool. (CWL or WDL)

--- a/src/main/resources/swagger/ga4gh-tool-discovery.yaml
+++ b/src/main/resources/swagger/ga4gh-tool-discovery.yaml
@@ -154,8 +154,8 @@ paths:
           enum:
             - CWL
             - WDL
-            - plain-CWL
-            - plain-WDL
+            - PLAIN_CWL
+            - PLAIN_WDL
         - name: id
           in: path
           description: A unique identifier of the tool, scoped to this registry, for example `123456`
@@ -194,8 +194,8 @@ paths:
           enum:
             - CWL
             - WDL
-            - plain-CWL
-            - plain-WDL
+            - PLAIN_CWL
+            - PLAIN_WDL
         - name: id
           in: path
           description: A unique identifier of the tool, scoped to this registry, for example `123456`
@@ -239,8 +239,8 @@ paths:
           enum:
             - CWL
             - WDL
-            - plain-CWL
-            - plain-WDL
+            - PLAIN_CWL
+            - PLAIN_WDL
         - name: id
           in: path
           description: A unique identifier of the tool, scoped to this registry, for example `123456`
@@ -379,7 +379,7 @@ definitions:
       verified:
         type: boolean
         description: Reports whether this tool has been verified by a specific organization or individual
-      verified-source:
+      verified_source:
         type: string
         description: Source of metadata that can support a verified tool, such as an email or URL
       signed:

--- a/src/main/resources/swagger/ga4gh-tool-discovery.yaml
+++ b/src/main/resources/swagger/ga4gh-tool-discovery.yaml
@@ -326,6 +326,7 @@ paths:
 
 definitions:
   ToolClass:
+    type: object
     # thought. it would be nicer if ToolClasses are consistent across registries. How would we accomplish this? Operate a MIME-type like list?
     description: Describes a class (type) of tool allowing us to categorize workflows, tools, and maybe even other entities (such as services) separately
     properties:
@@ -339,6 +340,7 @@ definitions:
         type: string
         description: A longer explanation of what this class is and what it can accomplish
   Tool:
+    type: object
     description: A tool (or described tool) describes one pairing of a tool as described in a descriptor file (which potentially describes multiple tools) and a Docker image.
     required:
       - url
@@ -392,6 +394,7 @@ definitions:
         items:
           $ref: '#/definitions/ToolVersion'
   ToolVersion:
+    type: object
     description: A tool version describes a particular iteration of a tool as described by a reference to a specific image and dockerfile.
     required:
       - url
@@ -431,6 +434,7 @@ definitions:
         type: string
         description: Source of metadata that can support a verified tool, such as an email or URL
   ToolDescriptor:
+    type: object
     description: A tool descriptor is a metadata document that describes one or more tools.
     required:
       - type
@@ -448,6 +452,7 @@ definitions:
         type: string
         description: 'Optional url to the tool descriptor used to build this image, should include version information, and can include a git hash (e.g. https://raw.githubusercontent.com/ICGC-TCGA-PanCancer/pcawg_delly_workflow/ea2a5db69bd20a42976838790bc29294df3af02b/delly_docker/Delly.cwl )'
   ToolTests:
+    type: object
     description: A tool document that describes how to test with one or more sample test JSON.
     required:
       - test
@@ -459,6 +464,7 @@ definitions:
         type: string
         description: 'Optional url to the test JSON used to test this tool'
   ToolDockerfile:
+    type: object
     description: A tool dockerfile is a document that describes how to build a particular Docker image.
     required:
       - dockerfile
@@ -470,6 +476,7 @@ definitions:
         type: string
         description: 'Optional url to the dockerfile used to build this image, should include version information, and can include a git hash  (e.g. https://raw.githubusercontent.com/ICGC-TCGA-PanCancer/pcawg_delly_workflow/c83478829802b4d36374870843821abe1b625a71/delly_docker/Dockerfile )'
   Metadata:
+    type: object
     description: Describes this registry to better allow for mirroring and indexing.
     required:
       - version
@@ -489,6 +496,7 @@ definitions:
         description: A friendly name that can be used in addition to the hostname to describe a registry
 
   Error:
+    type: object
     required:
      - code
     properties:

--- a/src/main/resources/swagger/ga4gh-tool-discovery.yaml
+++ b/src/main/resources/swagger/ga4gh-tool-discovery.yaml
@@ -23,6 +23,7 @@ paths:
           required: true
           type: string
           description: A unique identifier of the tool, scoped to this registry, for example `123456`
+          x-example: 'registry.hub.docker.com/sequenza/sequenza'
       responses:
         '200':
           description: A tool.
@@ -41,6 +42,7 @@ paths:
           required: true
           type: string
           description: A unique identifier of the tool, scoped to this registry, for example `123456`
+          x-example: 'registry.hub.docker.com/sequenza/sequenza'
       responses:
         '200':
           description: An array of tool versions
@@ -61,11 +63,13 @@ paths:
           required: true
           type: string
           description: A unique identifier of the tool, scoped to this registry, for example `123456`
+          x-example: 'registry.hub.docker.com/sequenza/sequenza'
         - name: version-id
           in: path
           required: true
           type: string
           description: An identifier of the tool version, scoped to this registry, for example `v1`
+          x-example: 'latest'
       responses:
         '200':
           description: A tool version.
@@ -152,16 +156,19 @@ paths:
             - WDL
             - plain-CWL
             - plain-WDL
+          x-example: 'CWL'
         - name: id
           in: path
           description: A unique identifier of the tool, scoped to this registry, for example `123456`
           required: true
           type: string
+          x-example: 'registry.hub.docker.com/sequenza/sequenza'
         - name: version-id
           in: path
           required: true
           type: string
           description: An identifier of the tool version for this particular tool registry, for example `v1`
+          x-example: 'latest'
       responses:
         '200':
           description: The tool descriptor.
@@ -190,21 +197,25 @@ paths:
             - WDL
             - plain-CWL
             - plain-WDL
+          x-example: 'CWL'
         - name: id
           in: path
           description: A unique identifier of the tool, scoped to this registry, for example `123456`
           required: true
           type: string
+          x-example: 'registry.hub.docker.com/sequenza/sequenza'
         - name: version-id
           in: path
           required: true
           type: string
           description: An identifier of the tool version for this particular tool registry, for example `v1`
+          x-example: 'latest'
         - name: relative-path
           in: path
           required: true
           type: string
           description: A relative path to the additional file (same directory or subdirectories), for example 'foo.cwl' would return a 'foo.cwl' from the same directory as the main descriptor
+          x-example: '/sequenza.cwl'
       responses:
         '200':
           description: The tool descriptor.
@@ -232,16 +243,19 @@ paths:
             - WDL
             - plain-CWL
             - plain-WDL
+          x-example: 'CWL'
         - name: id
           in: path
           description: A unique identifier of the tool, scoped to this registry, for example `123456`
           required: true
           type: string
+          x-example: 'registry.hub.docker.com/sequenza/sequenza'
         - name: version-id
           in: path
           required: true
           type: string
           description: An identifier of the tool version for this particular tool registry, for example `v1`
+          x-example: 'latest'
       responses:
         '200':
           description: The tool test JSON response.
@@ -266,11 +280,13 @@ paths:
           description: A unique identifier of the tool, scoped to this registry, for example `123456`
           required: true
           type: string
+          x-example: 'registry.hub.docker.com/sequenza/sequenza'
         - name: version-id
           in: path
           required: true
           type: string
           description: An identifier of the tool version for this particular tool registry, for example `v1`
+          x-example: 'latest'
       responses:
         '200':
           description: The tool payload.
@@ -500,4 +516,3 @@ parameters:
 externalDocs:
   description: Description of GA4GH Tool Registry (Exchange) Schema
   url: 'https://github.com/ga4gh/tool-registry-schemas'
-

--- a/src/main/resources/swagger/ga4gh-tool-discovery.yaml
+++ b/src/main/resources/swagger/ga4gh-tool-discovery.yaml
@@ -23,7 +23,6 @@ paths:
           required: true
           type: string
           description: A unique identifier of the tool, scoped to this registry, for example `123456`
-          x-example: 'registry.hub.docker.com/sequenza/sequenza'
       responses:
         '200':
           description: A tool.
@@ -42,7 +41,6 @@ paths:
           required: true
           type: string
           description: A unique identifier of the tool, scoped to this registry, for example `123456`
-          x-example: 'registry.hub.docker.com/sequenza/sequenza'
       responses:
         '200':
           description: An array of tool versions
@@ -63,13 +61,11 @@ paths:
           required: true
           type: string
           description: A unique identifier of the tool, scoped to this registry, for example `123456`
-          x-example: 'registry.hub.docker.com/sequenza/sequenza'
         - name: version_id
           in: path
           required: true
           type: string
           description: An identifier of the tool version, scoped to this registry, for example `v1`
-          x-example: 'latest'
       responses:
         '200':
           description: A tool version.
@@ -161,13 +157,11 @@ paths:
           description: A unique identifier of the tool, scoped to this registry, for example `123456`
           required: true
           type: string
-          x-example: 'registry.hub.docker.com/sequenza/sequenza'
         - name: version_id
           in: path
           required: true
           type: string
           description: An identifier of the tool version for this particular tool registry, for example `v1`
-          x-example: 'latest'
       responses:
         '200':
           description: The tool descriptor.
@@ -201,19 +195,16 @@ paths:
           description: A unique identifier of the tool, scoped to this registry, for example `123456`
           required: true
           type: string
-          x-example: 'registry.hub.docker.com/sequenza/sequenza'
         - name: version_id
           in: path
           required: true
           type: string
           description: An identifier of the tool version for this particular tool registry, for example `v1`
-          x-example: 'latest'
         - name: relative_path
           in: path
           required: true
           type: string
           description: A relative path to the additional file (same directory or subdirectories), for example 'foo.cwl' would return a 'foo.cwl' from the same directory as the main descriptor
-          x-example: '/sequenza.cwl'
       responses:
         '200':
           description: The tool descriptor.
@@ -246,13 +237,11 @@ paths:
           description: A unique identifier of the tool, scoped to this registry, for example `123456`
           required: true
           type: string
-          x-example: 'registry.hub.docker.com/sequenza/sequenza'
         - name: version_id
           in: path
           required: true
           type: string
           description: An identifier of the tool version for this particular tool registry, for example `v1`
-          x-example: 'latest'
       responses:
         '200':
           description: The tool test JSON response.
@@ -277,13 +266,11 @@ paths:
           description: A unique identifier of the tool, scoped to this registry, for example `123456`
           required: true
           type: string
-          x-example: 'registry.hub.docker.com/sequenza/sequenza'
         - name: version_id
           in: path
           required: true
           type: string
           description: An identifier of the tool version for this particular tool registry, for example `v1`
-          x-example: 'latest'
       responses:
         '200':
           description: The tool payload.
@@ -521,3 +508,4 @@ parameters:
 externalDocs:
   description: Description of GA4GH Tool Registry (Exchange) Schema
   url: 'https://github.com/ga4gh/tool-registry-schemas'
+

--- a/src/main/resources/swagger/ga4gh-tool-discovery.yaml
+++ b/src/main/resources/swagger/ga4gh-tool-discovery.yaml
@@ -51,7 +51,7 @@ paths:
             items:
               $ref: '#/definitions/ToolVersion'
 
-  /tools/{id}/versions/{version-id}:
+  /tools/{id}/versions/{version_id}:
     get:
       summary: List one specific tool version, acts as an anchor for self references
       description: This endpoint returns one specific tool version
@@ -64,7 +64,7 @@ paths:
           type: string
           description: A unique identifier of the tool, scoped to this registry, for example `123456`
           x-example: 'registry.hub.docker.com/sequenza/sequenza'
-        - name: version-id
+        - name: version_id
           in: path
           required: true
           type: string
@@ -138,7 +138,7 @@ paths:
 
 
 
-  /tools/{id}/versions/{version-id}/{type}/descriptor:
+  /tools/{id}/versions/{version_id}/{type}/descriptor:
     get:
       summary: Get the tool descriptor (CWL/WDL) for the specified tool.
       description: Returns the CWL or WDL descriptor for the specified tool.
@@ -163,7 +163,7 @@ paths:
           required: true
           type: string
           x-example: 'registry.hub.docker.com/sequenza/sequenza'
-        - name: version-id
+        - name: version_id
           in: path
           required: true
           type: string
@@ -179,7 +179,7 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 
-  /tools/{id}/versions/{version-id}/{type}/descriptor/{relative-path}:
+  /tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path}:
     get:
       summary: Get additional tool descriptor files (CWL/WDL) relative to the main file
       description: Returns additional CWL or WDL descriptors for the specified tool in the same or subdirectories
@@ -204,13 +204,13 @@ paths:
           required: true
           type: string
           x-example: 'registry.hub.docker.com/sequenza/sequenza'
-        - name: version-id
+        - name: version_id
           in: path
           required: true
           type: string
           description: An identifier of the tool version for this particular tool registry, for example `v1`
           x-example: 'latest'
-        - name: relative-path
+        - name: relative_path
           in: path
           required: true
           type: string
@@ -226,7 +226,7 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 
-  /tools/{id}/versions/{version-id}/{type}/tests:
+  /tools/{id}/versions/{version_id}/{type}/tests:
     get:
       summary: Get an array of test JSONs suitable for use with this descriptor type.
       tags:
@@ -250,7 +250,7 @@ paths:
           required: true
           type: string
           x-example: 'registry.hub.docker.com/sequenza/sequenza'
-        - name: version-id
+        - name: version_id
           in: path
           required: true
           type: string
@@ -268,7 +268,7 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 
-  /tools/{id}/versions/{version-id}/dockerfile:
+  /tools/{id}/versions/{version_id}/dockerfile:
     get:
       summary: Get the dockerfile for the specified image.
       description: Returns the dockerfile for the specified image.
@@ -281,7 +281,7 @@ paths:
           required: true
           type: string
           x-example: 'registry.hub.docker.com/sequenza/sequenza'
-        - name: version-id
+        - name: version_id
           in: path
           required: true
           type: string

--- a/src/main/resources/swagger/ga4gh-tool-discovery.yaml
+++ b/src/main/resources/swagger/ga4gh-tool-discovery.yaml
@@ -138,7 +138,7 @@ paths:
 
 
 
-  /tools/{id}/versions/{version_id}/{type}/descriptor:
+  /tools/{id}/versions/{version_id}/descriptor:
     get:
       summary: Get the tool descriptor (CWL/WDL) for the specified tool.
       description: Returns the CWL or WDL descriptor for the specified tool.
@@ -147,7 +147,7 @@ paths:
       parameters:
         - name: type
           required: true
-          in: path
+          in: query
           description: The output type of the descriptor. If not specified it is up to the underlying implementation to determine which output type to return. Plain types return the bare descriptor while the "non-plain" types return a descriptor wrapped
             with metadata
           type: string
@@ -156,7 +156,6 @@ paths:
             - WDL
             - plain-CWL
             - plain-WDL
-          x-example: 'CWL'
         - name: id
           in: path
           description: A unique identifier of the tool, scoped to this registry, for example `123456`
@@ -179,7 +178,7 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 
-  /tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path}:
+  /tools/{id}/versions/{version_id}/descriptor/{relative_path}:
     get:
       summary: Get additional tool descriptor files (CWL/WDL) relative to the main file
       description: Returns additional CWL or WDL descriptors for the specified tool in the same or subdirectories
@@ -187,7 +186,7 @@ paths:
         - GA4GH
       parameters:
         - name: type
-          in: path
+          in: query
           required: true
           description: The output type of the descriptor. If not specified it is up to the underlying implementation to determine which output type to return.  Plain types return the bare descriptor while the "non-plain" types return a descriptor wrapped
             with metadata
@@ -197,7 +196,6 @@ paths:
             - WDL
             - plain-CWL
             - plain-WDL
-          x-example: 'CWL'
         - name: id
           in: path
           description: A unique identifier of the tool, scoped to this registry, for example `123456`
@@ -226,7 +224,7 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 
-  /tools/{id}/versions/{version_id}/{type}/tests:
+  /tools/{id}/versions/{version_id}/tests:
     get:
       summary: Get an array of test JSONs suitable for use with this descriptor type.
       tags:
@@ -234,7 +232,7 @@ paths:
       parameters:
         - name: type
           required: true
-          in: path
+          in: query
           description: The output type of the descriptor. If not specified it is up to the underlying implementation to determine which output type to return. Plain types return the bare descriptor while the "non-plain" types return a descriptor wrapped
             with metadata
           type: string
@@ -243,7 +241,6 @@ paths:
             - WDL
             - plain-CWL
             - plain-WDL
-          x-example: 'CWL'
         - name: id
           in: path
           description: A unique identifier of the tool, scoped to this registry, for example `123456`

--- a/src/main/resources/swagger/ga4gh-tool-discovery.yaml
+++ b/src/main/resources/swagger/ga4gh-tool-discovery.yaml
@@ -134,7 +134,7 @@ paths:
 
 
 
-  /tools/{id}/versions/{version_id}/descriptor:
+  /tools/{id}/versions/{version_id}/{type}/descriptor:
     get:
       summary: Get the tool descriptor (CWL/WDL) for the specified tool.
       description: Returns the CWL or WDL descriptor for the specified tool.
@@ -143,15 +143,9 @@ paths:
       parameters:
         - name: type
           required: true
-          in: query
-          description: The output type of the descriptor. If not specified it is up to the underlying implementation to determine which output type to return. Plain types return the bare descriptor while the "non-plain" types return a descriptor wrapped
-            with metadata
+          in: path
+          description: The output type of the descriptor. If not specified it is up to the underlying implementation to determine which output type to return. Plain types return the bare descriptor while the "non-plain" types return a descriptor wrapped with metadata. Allowable values are "CWL", "WDL", "PLAIN_CWL", "PLAIN_WDL".
           type: string
-          enum:
-            - CWL
-            - WDL
-            - PLAIN_CWL
-            - PLAIN_WDL
         - name: id
           in: path
           description: A unique identifier of the tool, scoped to this registry, for example `123456`
@@ -172,7 +166,7 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 
-  /tools/{id}/versions/{version_id}/descriptor/{relative_path}:
+  /tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path}:
     get:
       summary: Get additional tool descriptor files (CWL/WDL) relative to the main file
       description: Returns additional CWL or WDL descriptors for the specified tool in the same or subdirectories
@@ -180,16 +174,10 @@ paths:
         - GA4GH
       parameters:
         - name: type
-          in: query
+          in: path
           required: true
-          description: The output type of the descriptor. If not specified it is up to the underlying implementation to determine which output type to return.  Plain types return the bare descriptor while the "non-plain" types return a descriptor wrapped
-            with metadata
+          description: The output type of the descriptor. If not specified it is up to the underlying implementation to determine which output type to return. Plain types return the bare descriptor while the "non-plain" types return a descriptor wrapped with metadata. Allowable values are "CWL", "WDL", "PLAIN_CWL", "PLAIN_WDL".
           type: string
-          enum:
-            - CWL
-            - WDL
-            - PLAIN_CWL
-            - PLAIN_WDL
         - name: id
           in: path
           description: A unique identifier of the tool, scoped to this registry, for example `123456`
@@ -215,7 +203,7 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 
-  /tools/{id}/versions/{version_id}/tests:
+  /tools/{id}/versions/{version_id}/{type}/tests:
     get:
       summary: Get an array of test JSONs suitable for use with this descriptor type.
       tags:
@@ -223,15 +211,9 @@ paths:
       parameters:
         - name: type
           required: true
-          in: query
-          description: The output type of the descriptor. If not specified it is up to the underlying implementation to determine which output type to return. Plain types return the bare descriptor while the "non-plain" types return a descriptor wrapped
-            with metadata
+          in: path
+          description: The output type of the descriptor. If not specified it is up to the underlying implementation to determine which output type to return. Plain types return the bare descriptor while the "non-plain" types return a descriptor wrapped with metadata. Allowable values are "CWL", "WDL", "PLAIN_CWL", "PLAIN_WDL".
           type: string
-          enum:
-            - CWL
-            - WDL
-            - PLAIN_CWL
-            - PLAIN_WDL
         - name: id
           in: path
           description: A unique identifier of the tool, scoped to this registry, for example `123456`

--- a/src/main/resources/swagger/ga4gh-tool-discovery.yaml
+++ b/src/main/resources/swagger/ga4gh-tool-discovery.yaml
@@ -6,7 +6,7 @@ info:
 produces:
   - application/json
   - text/plain
-basePath: /api/ga4gh/v1
+basePath: /api/ga4gh/v2
 tags:
   - name: GA4GH
     description: A set of resources proposed as a common standard for tool repositories

--- a/src/main/resources/swagger/ga4gh-tool-discovery.yaml
+++ b/src/main/resources/swagger/ga4gh-tool-discovery.yaml
@@ -123,16 +123,16 @@ paths:
             items:
               $ref: '#/definitions/Tool'
           headers:
-            next-page:
+            next_page:
               description: A URL that can be used to reach the next page based on the current offset and page record limit
               type: string
-            last-page:
+            last_page:
               description: A URL that can be used to reach the last page based on the current page record limit
               type: string
-            current-offset:
+            current_offset:
               description: The current start index of the paging used for this result
               type: string
-            current-limit:
+            current_limit:
               description: The current page record limit used for this result
               type: integer
 
@@ -309,7 +309,7 @@ paths:
           schema:
               $ref: '#/definitions/Metadata'
 
-  /tool-classes:
+  /toolClasses:
     get:
       summary: List all tool types
       description: >
@@ -347,7 +347,7 @@ definitions:
       - id
       - organization
       - author
-      - meta-version
+      - meta_version
       - toolclass
       - versions
     properties:
@@ -371,7 +371,7 @@ definitions:
       author:
         type: string
         description: Contact information for the author of this tool entry in the registry. (More complex authorship information is handled by the descriptor)
-      meta-version:
+      meta_version:
         type: string
         description: 'The version of this tool in the registry. Iterates when fields like the description, author, etc. are updated.'
       contains:
@@ -399,7 +399,7 @@ definitions:
     required:
       - url
       - id
-      - meta-version
+      - meta_version
     properties:
       name:
         type: string
@@ -413,7 +413,7 @@ definitions:
       image:
         type: string
         description: The docker path to the image (and version) for this tool. (e.g. quay.io/seqware/seqware_full/1.1)
-      descriptor-type:
+      descriptor_type:
         type: array
         description: The type (or types) of descriptors available.
         items:
@@ -424,13 +424,13 @@ definitions:
       dockerfile:
         type: boolean
         description: Reports if this tool has a dockerfile available.
-      meta-version:
+      meta_version:
         type: string
         description: 'The version of this tool version in the registry. Iterates when fields like the description, author, etc. are updated.'
       verified:
         type: boolean
         description: Reports whether this tool has been verified by a specific organization or individual
-      verified-source:
+      verified_source:
         type: string
         description: Source of metadata that can support a verified tool, such as an email or URL
   ToolDescriptor:
@@ -480,18 +480,18 @@ definitions:
     description: Describes this registry to better allow for mirroring and indexing.
     required:
       - version
-      - api-version
+      - api_version
     properties:
       version:
         type: string
         description: The version of this registry
-      api-version:
+      api_version:
         type: string
         description: The version of the GA4GH tool-registry API supported by this registry
       country:
         type: string
         description: A country code for the registry (ISO 3166-1 alpha-3)
-      friendly-name:
+      friendly_name:
         type: string
         description: A friendly name that can be used in addition to the hostname to describe a registry
 


### PR DESCRIPTION
Mainly style changes, also:
- explicitly define object types in the definitions 
- convert path param enum to string but with comments saying the allowable values since protobuf doesn't seem to support it
- added a work-in-progress protobuf file that was generated but then manually modified the enums

The .travis.yml that automatically generates the protobuf file is currently not present in this pull request because there's currently no deploy key for this repository yet (Travis would definitely fail the build).

See https://github.com/garyluu/validator/blob/master/.travis.yml for an similar travis file that automatically generates and uploads the protobuf file.